### PR TITLE
Added docker for local environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 .env
+/server/.mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+web:
+  image: phpdockerio/nginx:latest
+  restart: unless-stopped
+  container_name: ronald-webserver
+  volumes:
+      - ./:/var/www
+      - ./server/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+  ports:
+   - "8080:80"
+  links:
+   - php
+
+php:
+  build: .
+  dockerfile: ./server/php-fpm/Dockerfile
+  restart: unless-stopped
+  container_name: ronald-php-fpm
+  volumes:
+    - ./:/var/www
+    - ./server/php-fpm/php-ini-overrides.ini:/etc/php/7.0/fpm/conf.d/99-overrides.ini
+  links:
+    - db
+
+db:
+  image: playa/mysql
+  restart: unless-stopped
+  container_name: ronald-mariadb
+  ports:
+   - "3306:3306"
+  volumes:
+    - ./server/.mariadb:/var/lib/mysql
+  environment:
+    - MYSQL_ROOT_PASSWORD=beta
+    - MYSQL_DATABASE=ronald
+    - MYSQL_USER=ronald
+    - MYSQL_PASSWORD=ronald
+

--- a/server/nginx/nginx.conf
+++ b/server/nginx/nginx.conf
@@ -1,0 +1,36 @@
+server{
+   listen 80;
+   server_name _;
+
+   client_max_body_size 100M;
+   root /var/www/public;
+   index index.php index.html index.htm;
+   access_log /var/log/nginx/statuskit-admin.access.log;
+
+    #if ($http_x_forwarded_proto = 'http') {
+    #    return 301 https://$host$request_uri;
+    #}
+
+   location = /favicon.ico {
+	   log_not_found off;
+	   access_log off;
+   }
+
+   location ~ /\. {
+	   deny all;
+   }
+
+   if (!-e $request_filename) {
+       rewrite ^.*$ /index.php last;
+   }
+
+   location ~ \.php$ {
+       fastcgi_pass ronald-php-fpm:9000;
+       fastcgi_index index.php;
+       fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+       fastcgi_param PHP_VALUE "error_log=/var/log/nginx/statuskit_php_errors.log";
+       fastcgi_buffers 16 16k;
+       fastcgi_buffer_size 32k;
+       include fastcgi_params;
+   }
+}

--- a/server/php-fpm/Dockerfile
+++ b/server/php-fpm/Dockerfile
@@ -1,0 +1,11 @@
+FROM phpdockerio/php7-fpm:latest
+
+# Install selected extensions and other stuff
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install  php7.0-mysql php7.0-gd php7.0-geoip php7.0-mbstring \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+
+#RUN ln -s /var/www/storage/app/public /var/www/public/storage
+
+WORKDIR "/var/www"

--- a/server/php-fpm/php-ini-overrides.ini
+++ b/server/php-fpm/php-ini-overrides.ini
@@ -1,0 +1,3 @@
+upload_max_filesize = 2M
+post_max_size = 10M
+opcache.enable = 0


### PR DESCRIPTION
Please install docker and docker compose. This includes a php 7 container, nginx container and a mysql image. You can still use composer and npm in your local machine to install dependencies. The mysql contain is available network wide in port 3306, you can use sequel pro to access it. Please refer to `docker-compose.yml` for username and password.

Usage:
`docker-compose up -d` will bring the entire stack up
`docker-compose down` will take the entire stack down
`docker-compose logs -f` will steam you the log
`docker-compose exec php bash` will let you go into the bash shell of php container so that you can execute php artisan
